### PR TITLE
Fix arch function

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -11,7 +11,7 @@ get_arch() {
   local arch=""
 
   case "$(uname -m)" in
-    x86_64 | amd64) arch="amd64\|x86_64" ;;
+    x86_64 | amd64) arch='amd64\|x86_64' ;;
     aarch64 | arm64) arch="arm64" ;;
     *)
       fail "Arch '$(uname -m)' not supported!"


### PR DESCRIPTION
Closes #18

Looks like this should resolve the CI failures, we were failing to grep on the arch properly leading to a `Not Found` file being downloaded
