### PR TITLE
Fix/macos m1 issue

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -53,6 +53,10 @@ install_cue() {
     ext=".zip"
   fi
 
+  if [ "$platform" == "darwin" ]; then
+    arch="amd64\|x86_64"
+  fi
+
   local source_path="${install_path}/bin/cue${ext}"
   local distination="${install_path}/bin"
 


### PR DESCRIPTION
Hi,

fixed this issue #20,

because cue-lang didn't build arm binary for MacOS M1,

so I assigned only x86_64/amd64 version for MacOS.

I hope to help this plugin.

thanks !