### PR TITLE
Fail if the latest tag of cue has no downloadable release artifact

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -61,6 +61,11 @@ install_cue() {
     mkdir -p "$distination"
     download_file=$(curl -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/cue-lang/cue/releases/tags/v${version}" | grep "name" | grep "cue_v${version}\|cue_${version}" | awk '{print $2}' | grep -i "$platform" | grep -i "$arch" | sed -e 's/\"//g' | sed -e 's/,//g')
     echo "$download_file"
+    
+    if [ -z "$download_file" ]; then
+      fail "Version ${version} has no downloadable release. Maybe try a version before that?"
+    fi 
+   
     download_url="https://github.com/cue-lang/cue/releases/download/v${version}/$download_file"
     curl -L "$download_url" >"$source_path" || fail "Could not download $download_url"
     case $platform in


### PR DESCRIPTION
Some tags of cue don't publish a release artifact e.g. the last one 0.10.0-0.dev or the one in the issue #28 . Maybe we should just fail and inform if they don't publish a release. 