### PR TITLE
Fix the plugin add command for modern asdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## Installation
 
 ```bash
-asdf plugin-add cue https://github.com/asdf-community/asdf-cue.git
+asdf plugin add cue https://github.com/asdf-community/asdf-cue.git
 ```
 
 ## Usage


### PR DESCRIPTION
asdf syntax changed slightly with its Go rewrite, so the existing command in the README no longer works.

This fixes that problem.